### PR TITLE
Add xlink

### DIFF
--- a/components/BrailleTree.vue
+++ b/components/BrailleTree.vue
@@ -4,6 +4,7 @@
     :width="compwidth + 'mm'"
     :height="compheight + 'mm'"
     xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
   >
     <svg :x="_$.boarder + 'mm'" :y="compheight / 2 - 3.25 + 'mm'" style="overflow:visible;"> 
       <!-- Init Cell -->

--- a/components/Branch.vue
+++ b/components/Branch.vue
@@ -12,11 +12,11 @@
     <path :id="id" :d="dStr(for1, for2)"></path>
 
     <text
-      v-if="id != ''"
+      v-if="Boolean(id) == true"
       :dy="id == 'Bottom' ? '.9em' : '-.35em'"
       :font-size="+_$.size / 4 + 'mm'"
     >
-      <textPath :href="'#' + id" startOffset="25%" text-anchor="middle">
+      <textPath :xlink:href="'#' + id" startOffset="25%" text-anchor="middle">
         {{ id }}
       </textPath>
     </text>


### PR DESCRIPTION
xlink enables internal linking of element id's. Without this, textPath cannot find id specified in its href.

Fixed text render. id is undefined from secondary branches, thus it passed v-if. Undefined is falsy, thus i used boolean to catch it.